### PR TITLE
Stop Calling UIApplication Methods from Background Thread

### DIFF
--- a/PopcornTorrent/Source/Client/PTTorrentDownload.mm
+++ b/PopcornTorrent/Source/Client/PTTorrentDownload.mm
@@ -176,7 +176,9 @@ using namespace libtorrent;
     [self setDownloadStatus:PTTorrentDownloadStatusPaused];
     
     #if TARGET_OS_IOS
+      dispatch_async(dispatch_get_main_queue(), ^{
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+      });
     #endif
 }
 
@@ -195,7 +197,9 @@ using namespace libtorrent;
     [self setDownloadStatus:PTTorrentDownloadStatusDownloading];
     
     #if TARGET_OS_IOS
+      dispatch_async(dispatch_get_main_queue(), ^{
         [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
+      });
     #endif
 }
 
@@ -249,7 +253,9 @@ using namespace libtorrent;
     self.streaming = NO;
     
     #if TARGET_OS_IOS
+      dispatch_async(dispatch_get_main_queue(), ^{
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+      });
     #endif
 }
 

--- a/PopcornTorrent/Source/Client/PTTorrentStreamer.mm
+++ b/PopcornTorrent/Source/Client/PTTorrentStreamer.mm
@@ -220,7 +220,9 @@ using namespace libtorrent;
     if(_session->is_paused())_session->resume();
     
 #if TARGET_OS_IOS
+  dispatch_async(dispatch_get_main_queue(), ^{
     [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
+  });
 #endif
 }
 
@@ -318,7 +320,9 @@ using namespace libtorrent;
     _isFinished = false;
     
 #if TARGET_OS_IOS
+  dispatch_async(dispatch_get_main_queue(), ^{
     [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+  });
 #endif
 }
 
@@ -616,7 +620,9 @@ using namespace libtorrent;
     });
     
 #if TARGET_OS_IOS
-    [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+    });
 #endif
     
     // Remove the torrent when its finished


### PR DESCRIPTION
I saw these in Xcode 11:
```
runtime: UI API called from background thread: -[UIApplication setNetworkActivityIndicatorVisible:] must be used from main thread only
#0	0x00000001040e5573 in -[PTTorrentStreamer torrentFinishedAlert:] ()
#1	0x00000001040e3410 in -[PTTorrentStreamer alertsLoop] ()
#2	0x00000001054812cc in _dispatch_call_block_and_release ()
#3	0x000000010548128c in _dispatch_client_callout ()
#4	0x000000010548ff80 in _dispatch_queue_serial_drain ()
#5	0x00000001054847ec in _dispatch_queue_invoke ()
#6	0x0000000105490f6c in _dispatch_root_queue_drain_deferred_wlh ()
#7	0x0000000105498020 in _dispatch_workloop_worker_thread ()
#8	0x0000000182442f1c in _pthread_wqthread ()
#9	0x0000000182442b6c in start_wqthread ()
```

This pull request resolves those issues.